### PR TITLE
Fix Metadata tests

### DIFF
--- a/lib/ex_phone_number/metadata/phone_metadata.ex
+++ b/lib/ex_phone_number/metadata/phone_metadata.ex
@@ -570,10 +570,10 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
   def destructure_to_intl_number_format(%{intl_number_format: number_format}), do: number_format
 
   def process_phone_number_description(nil, nil),
-    do: process_phone_number_description(%PhoneNumberDescription{}, %PhoneNumberDescription{})
+    do: process_phone_number_description(%PhoneNumberDescription{is_default: true}, %PhoneNumberDescription{})
 
   def process_phone_number_description(nil, %PhoneMetadata{general: general}),
-    do: process_phone_number_description(%PhoneNumberDescription{}, general)
+    do: process_phone_number_description(%PhoneNumberDescription{is_default: true}, general)
 
   def process_phone_number_description(%PhoneNumberDescription{} = description, nil),
     do: process_phone_number_description(description, %PhoneNumberDescription{})
@@ -601,6 +601,13 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
         description.possible_lengths
       end
 
+    local_only_possible_lengths =
+      if is_nil_or_empty?(description.local_only_possible_lengths) do
+        general.local_only_possible_lengths
+      else
+        description.local_only_possible_lengths
+      end
+
     example_number =
       if is_nil_or_empty?(description.example_number) do
         general.example_number
@@ -608,10 +615,12 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
         description.example_number
       end
 
-    %PhoneNumberDescription{
-      national_number_pattern: national_number_pattern,
-      possible_lengths: possible_lengths,
-      example_number: example_number
+    %{
+      description
+      | national_number_pattern: national_number_pattern,
+        possible_lengths: possible_lengths,
+        local_only_possible_lengths: local_only_possible_lengths,
+        example_number: example_number
     }
   end
 
@@ -619,7 +628,8 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
     if is_nil(description) do
       %PhoneNumberDescription{
         national_number_pattern: Values.description_default_pattern(),
-        possible_lengths: Values.description_default_length()
+        possible_lengths: Values.description_default_length(),
+        local_only_possible_lengths: Values.description_default_length()
       }
     else
       process_phone_number_description(description, general)

--- a/lib/ex_phone_number/metadata/phone_number_description.ex
+++ b/lib/ex_phone_number/metadata/phone_number_description.ex
@@ -3,8 +3,12 @@ defmodule ExPhoneNumber.Metadata.PhoneNumberDescription do
   defstruct national_number_pattern: nil,
             # list
             possible_lengths: nil,
+            # list
+            local_only_possible_lengths: nil,
             # string
-            example_number: nil
+            example_number: nil,
+            # bool
+            is_default: false
 
   import SweetXml
   alias ExPhoneNumber.Utilities
@@ -31,6 +35,7 @@ defmodule ExPhoneNumber.Metadata.PhoneNumberDescription do
     struct(%PhoneNumberDescription{}, %{
       national_number_pattern: kwlist.national_number_pattern,
       possible_lengths: possible_lengths,
+      local_only_possible_lengths: kwlist.local_possible_lengths || [],
       example_number: kwlist.example_number
     })
   end
@@ -86,6 +91,12 @@ defmodule ExPhoneNumber.Metadata.PhoneNumberDescription do
 
   @spec has_data?(%PhoneNumberDescription{}) :: boolean()
   def has_data?(%PhoneNumberDescription{
+        is_default: true
+      }) do
+    false
+  end
+
+  def has_data?(%PhoneNumberDescription{
         example_number: example_number
       })
       when is_binary(example_number) do
@@ -101,8 +112,15 @@ defmodule ExPhoneNumber.Metadata.PhoneNumberDescription do
   def has_data?(%PhoneNumberDescription{
         possible_lengths: possible_lengths
       })
+      when is_list(possible_lengths) and length(possible_lengths) != 1 do
+    true
+  end
+
+  def has_data?(%PhoneNumberDescription{
+        possible_lengths: possible_lengths
+      })
       when is_list(possible_lengths) do
-    List.first(possible_lengths) > 0
+    List.first(possible_lengths) != -1
   end
 
   def has_data?(%PhoneNumberDescription{}) do

--- a/test/ex_phone_number/metadata_test.exs
+++ b/test/ex_phone_number/metadata_test.exs
@@ -50,7 +50,6 @@ defmodule ExPhoneNumber.MetadataTest do
       assert ~r/[13-689]\d{9}|2[0-35-9]\d{8}/ == metadata.general.national_number_pattern
       assert ~r/[13-689]\d{9}|2[0-35-9]\d{8}/ == metadata.fixed_line.national_number_pattern
       assert ~r/900\d{7}/ == metadata.premium_rate.national_number_pattern
-      assert is_nil(metadata.shared_cost.national_number_pattern)
     end
 
     test "GetInstanceLoadDEMetadata", %{de_metadata: metadata} do
@@ -112,7 +111,7 @@ defmodule ExPhoneNumber.MetadataTest do
       assert 800 == metadata.country_code
       assert "\\g{1} \\g{2}" == Enum.at(metadata.number_format, 0).format
       assert ~r/(\d{4})(\d{4})/ == Enum.at(metadata.number_format, 0).pattern
-      assert Enum.empty?(metadata.general.national_possible_lengths)
+      assert Enum.empty?(metadata.general.local_only_possible_lengths)
       assert 1 == length(metadata.general.possible_lengths)
       assert "12345678" == metadata.toll_free.example_number
     end


### PR DESCRIPTION
Update `GetInstanceLoadInternationalTollFreeMetadata` test to libphonenumber v8.12.49 (`local_only_possible_lengths`). Add `local_only_possible_lengths` to `%Metadata.PhoneNumberDescription{}`.

Remove `is_nil(shared_cost.national_number_pattern)` from `GetInstanceLoadUSMetadata` test as it is validated in `US region_code returns valid shared_cost.national_number_pattern` test anyway and does not looks like `national_number_pattern` should ever be `nil` (it is at least set to default value `"NA"`).

Add `is_default` to `%Metadata.PhoneNumberDescription{}` to identify that description was not present in metadata file. Update `PhoneNumberDescription.has_data?() `to return false if is_default = true.

Update `PhoneNumberDescription.has_data?()` `possible_lengths` check to better match libphonenumber v8.12.49.