### PR TITLE
Upgrade required elixir to 1.11 and fix warnings

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :logger,
   backends: [:console]

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :ex_phone_number,
   log_level: :debug

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :ex_phone_number,
   log_level: :info

--- a/lib/ex_phone_number/metadata/phone_metadata.ex
+++ b/lib/ex_phone_number/metadata/phone_metadata.ex
@@ -68,7 +68,7 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
   alias ExPhoneNumber.Metadata.PhoneNumberDescription
 
   require Logger
-  Logger.configure(level: Application.get_env(:ex_phone_number, :log_level, :warn))
+  Logger.configure(level: Application.compile_env(:ex_phone_number, :log_level, :warn))
 
   def from_xpath_node(xpath_node) do
     kwlist =

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule ExPhoneNumber.Mixfile do
     [
       app: :ex_phone_number,
       version: @version,
-      elixir: "~> 1.4",
+      elixir: "~> 1.11",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],

--- a/mix.exs
+++ b/mix.exs
@@ -41,10 +41,12 @@ defmodule ExPhoneNumber.Mixfile do
   end
 
   defp package do
-    [files: ["lib", "config", "resources", "LICENSE*", "README*", "mix.exs"],
-     licenses: ["MIT"],
-     links: %{"GitHub" => "https://github.com/socialpaymentsbv/ex_phone_number"},
-     maintainers: ["ClubCollect (@socialpaymentsbv)",  "Jose Miguel Rivero Bruno (@josemrb)"],
-     name: :ex_phone_number]
+    [
+      files: ["lib", "config", "resources", "LICENSE*", "README*", "mix.exs"],
+      licenses: ["MIT"],
+      links: %{"GitHub" => "https://github.com/socialpaymentsbv/ex_phone_number"},
+      maintainers: ["ClubCollect (@socialpaymentsbv)", "Jose Miguel Rivero Bruno (@josemrb)"],
+      name: :ex_phone_number
+    ]
   end
 end


### PR DESCRIPTION
- Upgrade minimum required elixir version to 1.11
- Remove warnings
```bash
warning: use Mix.Config is deprecated. Use the Config module instead
  config/test.exs:1

warning: Application.get_env/3 is discouraged in the module body, use Application.compile_env/3 instead
  lib/ex_phone_number/metadata/phone_metadata.ex:71: ExPhoneNumber.Metadata.PhoneMetadata
```
