### PR TITLE
fix: use Application.compile_env/3 rather than Application.get_env/3

### DIFF
--- a/lib/ex_phone_number/metadata/phone_metadata.ex
+++ b/lib/ex_phone_number/metadata/phone_metadata.ex
@@ -68,7 +68,7 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
   alias ExPhoneNumber.Metadata.PhoneNumberDescription
 
   require Logger
-  Logger.configure(level: Application.get_env(:ex_phone_number, :log_level, :warn))
+  Logger.configure(level: Application.compile_env(:ex_phone_number, :log_level, :warn))
 
   def from_xpath_node(xpath_node) do
     kwlist =


### PR DESCRIPTION
Fix the following warning:

```elixir
warning: Application.get_env/3 is discouraged in the module body, use Application.compile_env/3 instead
  lib/ex_phone_number/metadata/phone_metadata.ex:71: ExPhoneNumber.Metadata.PhoneMetadata
```

Note: https://hexdocs.pm/elixir/1.12/Application.html#compile_env/3 (since 1.10)