### PR TITLE
Make Tesla an optional dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,9 +28,9 @@ defmodule ExPhoneNumber.Mixfile do
       {:sweet_xml, "~> 0.7"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:ex_spec, "~> 2.0", only: :test},
-      {:tesla, "~> 1.4", only: [:dev, :test]},
-      {:hackney, "~> 1.17", only: [:dev, :test]},
-      {:jason, ">= 1.0.0", only: [:dev, :test]}
+      {:tesla, "~> 1.4", only: [:dev, :test], optional: true},
+      {:hackney, "~> 1.17", only: [:dev, :test], optional: true},
+      {:jason, ">= 1.0.0", only: [:dev, :test], optional: true}
     ]
   end
 


### PR DESCRIPTION
Why: 
 - To avoid apps that use `ex_phone_number` to have `tesla` in their direct dependencies if they don't need/don't plan to run the upgrade metadata task.

How:
 - Making `tesla` and the other associated deps optional.
 - Replace `use Tesla` macro with the `client` version so that when calling `latest_release` function, we can verify if `tesla` is loaded or not.