### PR TITLE
Replace deprecated log level `:warn`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,9 @@ jobs:
           # Only Elixir 1.14 supports OTP 25
           - otp: "25.3"
             elixir: "1.14.4"
-          # We need to test Elixir 1.10 for backwards compatibility
+          # We need to test Elixir 1.11 for backwards compatibility
           - otp: "22.3.4.26"
-            elixir: "1.10.4"
+            elixir: "1.11.4"
     steps:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1

--- a/lib/ex_phone_number/metadata/phone_metadata.ex
+++ b/lib/ex_phone_number/metadata/phone_metadata.ex
@@ -70,7 +70,7 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
   alias ExPhoneNumber.Metadata.PhoneNumberDescription
 
   require Logger
-  Logger.configure(level: Application.compile_env(:ex_phone_number, :log_level, :warn))
+  Logger.configure(level: Application.compile_env(:ex_phone_number, :log_level, :warning))
 
   def from_xpath_node(xpath_node) do
     kwlist =

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule ExPhoneNumber.Mixfile do
       app: :ex_phone_number,
       version: @version,
       name: "ExPhoneNumber",
-      elixir: "~> 1.10",
+      elixir: "~> 1.11",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
with `:warning`, available [since Elixir 1.11](https://hexdocs.pm/logger/Logger.html#warning/2), currently the oldest [supported Elixir version](https://hexdocs.pm/elixir/1.15.2/compatibility-and-deprecations.html).