### PR TITLE
Update metadata (24-08-2023)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 ## [Unreleased]
 
-[0.4.2] - 2023-05-22
+### Changed
+
+- Updated metadata source file to v8.13.19
+
+## [0.4.2] - 2023-05-22
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Elixir library for parsing, formatting, and validating international phone numbers.
 Based on Google's [libphonenumber](https://github.com/googlei18n/libphonenumber).
 
-**Current metadata version: v8.13.12.**
+**Current metadata version: v8.13.19.**
 
 ## Installation
 

--- a/resources/PhoneNumberMetadata.xml
+++ b/resources/PhoneNumberMetadata.xml
@@ -758,7 +758,7 @@
             4[02-9]|
             5[0-46-9]|
             [6-8]\d|
-            9[01]
+            9[0-2]
           )\d{4}
         </nationalNumberPattern>
       </voip>
@@ -2525,9 +2525,11 @@
         <exampleNumber>412345678</exampleNumber>
         <nationalNumberPattern>
           4(?:
-            79[01]|
-            83[0-389]|
-            93[0-6]
+            (?:
+              79|
+              94
+            )[01]|
+            83[0-389]
           )\d{5}|
           4(?:
             [0-3]\d|
@@ -2536,7 +2538,7 @@
             6[016-9]|
             7[02-8]|
             8[0-24-9]|
-            9[0-27-9]
+            9[0-37-9]
           )\d{6}
         </nationalNumberPattern>
       </mobile>
@@ -3201,9 +3203,9 @@
               9
             )|
             6(?:
+              [15]|
               28|
-              4[14]|
-              5
+              4[14]
             )|
             7[2-589]|
             8(?:
@@ -3654,7 +3656,7 @@
               2[0-57]|
               3[04-7]|
               44|
-              6[569]|
+              6[4-69]|
               7[0579]
             )|
             90\d\d
@@ -3733,7 +3735,7 @@
         <nationalNumberPattern>
           (?:
             0[1-35-7]|
-            5[1-8]|
+            5[0-8]|
             [67]\d
           )\d{6}
         </nationalNumberPattern>
@@ -3888,7 +3890,7 @@
         <numberFormat pattern="(\d{4})(\d{4})">
           <leadingDigits>
             [13679]|
-            8[047]
+            8[02-4679]
           </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
@@ -3925,11 +3927,11 @@
               9[69][69]
             )|
             7(?:
+              [07]\d\d|
               1(?:
                 11|
                 78
-              )|
-              7\d\d
+              )
             )
           )\d{4}
         </nationalNumberPattern>
@@ -3943,8 +3945,8 @@
         <nationalNumberPattern>
           (?:
             3(?:
-              [1-79]\d|
-              8[0-47-9]
+              [0-79]\d|
+              8[0-57-9]
             )\d|
             6(?:
               3(?:
@@ -3952,6 +3954,7 @@
                 33|
                 6[16]
               )|
+              441|
               6(?:
                 3[03-9]|
                 [69]\d|
@@ -3964,7 +3967,7 @@
       <tollFree>
         <possibleLengths national="8"/>
         <exampleNumber>80123456</exampleNumber>
-        <nationalNumberPattern>80\d{6}</nationalNumberPattern>
+        <nationalNumberPattern>8[02369]\d{6}</nationalNumberPattern>
       </tollFree>
       <!-- 87 numbers are "wholly paid by the caller", so they are slotted under premium-rate for
            now. -->
@@ -3974,7 +3977,7 @@
         <nationalNumberPattern>
           (?:
             87|
-            9[014578]
+            9[0-8]
           )\d{6}
         </nationalNumberPattern>
       </premiumRate>
@@ -4068,7 +4071,7 @@
         <exampleNumber>90011234</exampleNumber>
         <nationalNumberPattern>
           (?:
-            4[0-256]|
+            4[0-356]|
             [56]\d|
             9[013-9]
           )\d{6}
@@ -4115,6 +4118,7 @@
         <nationalNumberPattern>
           590(?:
             2[7-9]|
+            3[3-7]|
             5[12]|
             87
           )\d{4}
@@ -4155,7 +4159,7 @@
               395|
               76[018]
             )\d|
-            475[0-2]
+            475[0-5]
           )\d{4}
         </nationalNumberPattern>
       </voip>
@@ -4917,7 +4921,7 @@
         <numberFormat pattern="(\d{3})(\d{4})">
           <leadingDigits>
             [24-6]|
-            3[15-79]
+            3[15-9]
           </leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
@@ -4964,7 +4968,8 @@
               1[0-35-9]|
               55|
               [69]\d|
-              7[013]
+              7[013]|
+              81
             )|
             4(?:
               6[03]|
@@ -5581,9 +5586,11 @@
         <exampleNumber>412345678</exampleNumber>
         <nationalNumberPattern>
           4(?:
-            79[01]|
-            83[0-389]|
-            93[0-6]
+            (?:
+              79|
+              94
+            )[01]|
+            83[0-389]
           )\d{5}|
           4(?:
             [0-3]\d|
@@ -5592,7 +5599,7 @@
             6[016-9]|
             7[02-8]|
             8[0-24-9]|
-            9[0-27-9]
+            9[0-37-9]
           )\d{6}
         </nationalNumberPattern>
       </mobile>
@@ -7520,7 +7527,7 @@
           <format>$1 $2</format>
         </numberFormat>
         <numberFormat pattern="(\d)(\d{7})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>5</leadingDigits>
+          <leadingDigits>[56]</leadingDigits>
           <format>$1 $2</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{7})" nationalPrefixFormattingRule="$NP$FG">
@@ -7532,6 +7539,7 @@
         <nationalNumberPattern>
           [27]\d{6,7}|
           [34]\d{5,7}|
+          63\d{6}|
           (?:
             5|
             8\d\d
@@ -7546,7 +7554,7 @@
         <nationalNumberPattern>
           (?:
             3[23]|
-            48
+            4[89]
           )\d{4,6}|
           (?:
             31|
@@ -7566,7 +7574,12 @@
       <mobile>
         <possibleLengths national="8"/>
         <exampleNumber>51234567</exampleNumber>
-        <nationalNumberPattern>5\d{7}</nationalNumberPattern>
+        <nationalNumberPattern>
+          (?:
+            5\d|
+            63
+          )\d{6}
+        </nationalNumberPattern>
       </mobile>
       <tollFree>
         <possibleLengths national="10"/>
@@ -7805,9 +7818,11 @@
         <exampleNumber>412345678</exampleNumber>
         <nationalNumberPattern>
           4(?:
-            79[01]|
-            83[0-389]|
-            93[0-6]
+            (?:
+              79|
+              94
+            )[01]|
+            83[0-389]
           )\d{5}|
           4(?:
             [0-3]\d|
@@ -7816,7 +7831,7 @@
             6[016-9]|
             7[02-8]|
             8[0-24-9]|
-            9[0-27-9]
+            9[0-37-9]
           )\d{6}
         </nationalNumberPattern>
       </mobile>
@@ -9168,7 +9183,7 @@
                     3[5-9]
                   )\d|
                   7(?:
-                    [3679]\d|
+                    [0-79]\d|
                     8[13-9]
                   )|
                   8(?:
@@ -9247,8 +9262,12 @@
           <format>$1 $2</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3})(\d{4})" nationalPrefixFormattingRule="$NP$FG">
-          <leadingDigits>[189]</leadingDigits>
+          <leadingDigits>[89]</leadingDigits>
           <format>$1 $2 $3</format>
+        </numberFormat>
+        <numberFormat pattern="(\d{2})(\d{8})" nationalPrefixFormattingRule="$NP$FG">
+          <leadingDigits>1</leadingDigits>
+          <format>$1 $2</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
@@ -9666,7 +9685,7 @@
         <possibleLengths national="9"/>
         <exampleNumber>911234567</exampleNumber>
         <nationalNumberPattern>
-          7001\d{5}|
+          700[1-9]\d{5}|
           (?:
             7(?:
               0[1-9]|
@@ -10105,9 +10124,11 @@
         <possibleLengths national="9"/>
         <exampleNumber>123456789</exampleNumber>
         <nationalNumberPattern>
+          59[1-9]\d{6}|
           (?:
-            [1-35]\d|
-            4[1-9]
+            [1-3]\d|
+            4[1-9]|
+            5[0-8]
           )\d{7}
         </nationalNumberPattern>
       </fixedLine>
@@ -10409,7 +10430,7 @@
                 4(?:
                   [0-5]\d\d|
                   69[7-9]|
-                  70[0-579]
+                  70[0-79]
                 )|
                 (?:
                   (?:
@@ -10422,99 +10443,98 @@
                   )
                 )\d
               )|
-              2(?:
-                (?:
-                  0[024-9]|
-                  2[3-9]|
-                  3[3-79]|
-                  4[1-689]|
-                  [58][02-9]|
-                  6[0-47-9]|
-                  7[013-9]|
-                  9\d
-                )\d\d|
-                1(?:
-                  [0-7]\d\d|
-                  8(?:
-                    [02]\d|
-                    1[0-46-9]
-                  )
-                )
-              )|
               (?:
-                3(?:
-                  0\d|
-                  1[0-8]|
-                  [25][02-9]|
-                  3[02-579]|
-                  [468][0-46-9]|
-                  7[1-35-79]|
-                  9[2-578]
+                2(?:
+                  (?:
+                    0[024-9]|
+                    2[3-9]|
+                    3[3-79]|
+                    4[1-689]|
+                    [58][02-9]|
+                    6[0-47-9]|
+                    7[013-9]|
+                    9\d
+                  )\d|
+                  1(?:
+                    [0-7]\d|
+                    8[0-2]
+                  )
                 )|
-                4(?:
-                  0[03-9]|
-                  [137]\d|
-                  [28][02-57-9]|
-                  4[02-69]|
-                  5[0-8]|
-                  [69][0-79]
-                )|
-                5(?:
-                  0[1-35-9]|
-                  [16]\d|
-                  2[024-9]|
-                  3[015689]|
-                  4[02-9]|
-                  5[03-9]|
-                  7[0-35-9]|
-                  8[0-468]|
-                  9[0-57-9]
-                )|
-                6(?:
-                  0[034689]|
-                  1\d|
-                  2[0-35689]|
-                  [38][013-9]|
-                  4[1-467]|
-                  5[0-69]|
-                  6[13-9]|
-                  7[0-8]|
-                  9[0-24578]
-                )|
-                7(?:
-                  0[0246-9]|
-                  2\d|
-                  3[0236-8]|
-                  4[03-9]|
-                  5[0-46-9]|
-                  6[013-9]|
-                  7[0-35-9]|
-                  8[024-9]|
-                  9[02-9]
-                )|
-                8(?:
-                  0[35-9]|
-                  2[1-57-9]|
-                  3[02-578]|
-                  4[0-578]|
-                  5[124-9]|
-                  6[2-69]|
-                  7\d|
-                  8[02-9]|
-                  9[02569]
-                )|
-                9(?:
-                  0[02-589]|
-                  [18]\d|
-                  2[02-689]|
-                  3[1-57-9]|
-                  4[2-9]|
-                  5[0-579]|
-                  6[2-47-9]|
-                  7[0-24578]|
-                  9[2-57]
-                )
-              )\d\d
+                (?:
+                  3(?:
+                    0\d|
+                    1[0-8]|
+                    [25][02-9]|
+                    3[02-579]|
+                    [468][0-46-9]|
+                    7[1-35-79]|
+                    9[2-578]
+                  )|
+                  4(?:
+                    0[03-9]|
+                    [137]\d|
+                    [28][02-57-9]|
+                    4[02-69]|
+                    5[0-8]|
+                    [69][0-79]
+                  )|
+                  5(?:
+                    0[1-35-9]|
+                    [16]\d|
+                    2[024-9]|
+                    3[015689]|
+                    4[02-9]|
+                    5[03-9]|
+                    7[0-35-9]|
+                    8[0-468]|
+                    9[0-57-9]
+                  )|
+                  6(?:
+                    0[034689]|
+                    1\d|
+                    2[0-35689]|
+                    [38][013-9]|
+                    4[1-467]|
+                    5[0-69]|
+                    6[13-9]|
+                    7[0-8]|
+                    9[0-24578]
+                  )|
+                  7(?:
+                    0[0246-9]|
+                    2\d|
+                    3[0236-8]|
+                    4[03-9]|
+                    5[0-46-9]|
+                    6[013-9]|
+                    7[0-35-9]|
+                    8[024-9]|
+                    9[02-9]
+                  )|
+                  8(?:
+                    0[35-9]|
+                    2[1-57-9]|
+                    3[02-578]|
+                    4[0-578]|
+                    5[124-9]|
+                    6[2-69]|
+                    7\d|
+                    8[02-9]|
+                    9[02569]
+                  )|
+                  9(?:
+                    0[02-589]|
+                    [18]\d|
+                    2[02-689]|
+                    3[1-57-9]|
+                    4[2-9]|
+                    5[0-579]|
+                    6[2-47-9]|
+                    7[0-24578]|
+                    9[2-57]
+                  )
+                )\d
+              )\d
             )|
             2(?:
               0[013478]|
@@ -10999,6 +11019,9 @@
             5(?:
               00(?:
                 0\d|
+                11|
+                22|
+                33|
                 44|
                 5[05]|
                 77|
@@ -11128,10 +11151,10 @@
         <exampleNumber>594101234</exampleNumber>
         <nationalNumberPattern>
           594(?:
-            [0239]\d|
-            [16][0-3]|
-            4[03-9]|
+            [02-49]\d|
+            1[0-4]|
             5[6-9]|
+            6[0-3]|
             80
           )\d{4}
         </nationalNumberPattern>
@@ -11164,7 +11187,7 @@
               396|
               76\d
             )\d|
-            476[0-2]
+            476[0-5]
           )\d{4}
         </nationalNumberPattern>
       </voip>
@@ -11469,9 +11492,8 @@
           (?:
             19|
             3[1-7]|
-            6[14689]|
+            [68][1-9]|
             70|
-            8[14-79]|
             9\d
           )\d{4}
         </nationalNumberPattern>
@@ -11643,7 +11665,7 @@
             0[1-68]|
             [14][0-24-9]|
             2[0-68]|
-            3[1289]|
+            3[1-9]|
             5[3-579]|
             [68][0-689]|
             7[08]|
@@ -11685,7 +11707,7 @@
               395|
               76[018]
             )\d|
-            475[0-2]
+            475[0-5]
           )\d{4}
         </nationalNumberPattern>
       </voip>
@@ -12314,7 +12336,7 @@
               )
             )|
             58(?:
-              0[1-8]|
+              0[1-9]|
               1[2-9]
             )
           )\d{4}
@@ -13359,19 +13381,19 @@
         <possibleLengths national="9"/>
         <exampleNumber>502345678</exampleNumber>
         <nationalNumberPattern>
+          55410\d{4}|
           5(?:
             (?:
-              [02368]\d|
-              [19][2-9]|
-              4[1-9]
+              [0-249][2-9]|
+              [36]\d|
+              8[3-7]
             )\d|
             5(?:
               01|
-              1[79]|
               2[2-9]|
               3[0-3]|
               4[34]|
-              5[015689]|
+              5[0-25689]|
               6[6-8]|
               7[0-267]|
               8[7-9]|
@@ -13422,14 +13444,18 @@
         <exampleNumber>771234567</exampleNumber>
         <nationalNumberPattern>
           7(?:
-            380|
+            38(?:
+              0\d|
+              5[09]|
+              88
+            )|
             8(?:
               33|
               55|
               77|
               81
-            )
-          )\d{5}|
+            )\d
+          )\d{4}|
           7(?:
             18|
             2[23]|
@@ -14885,13 +14911,14 @@
               [0-46]\d\d|
               5[15]0|
               8(?:
-                1\d|
+                [12]\d|
                 88
               )|
               9(?:
                 0[0-3]|
                 [19]\d|
                 21|
+                69|
                 77|
                 8[7-9]
               )
@@ -15565,7 +15592,7 @@
                 40|
                 5[06]|
                 6[2-589]|
-                7[025-9]|
+                7[0-25-9]|
                 8[04]|
                 9[4-9]
               )|
@@ -15872,8 +15899,15 @@
     <!-- http://www.soumu.go.jp/main_sosiki/joho_tsusin/top/tel_number/number_shitei.html -->
     <!-- https://www.itu.int/oth/T020200006D/en -->
     <!-- http://www.numberingplans.com/?page=dialling&sub=areacodes&ac=JP -->
+    <!-- nationalPrefixTransformRule is used here for purpose of capturing 0005999999 kind of
+         short codes without dropping intial '0' as national prefix. As we are using this field, the
+         library is unable to capture domestic carrier codes used, example input:
+         003768-0XX-YYYY-ZZZZ. Due to historic reasons, the parts that we captured in
+         nationalPrefixTransform rule can either be used to transform or to capture in fields like
+         preferred_domestic_carrier_code; schema is designed this way. -->
     <territory id="JP" countryCode="81" internationalPrefix="010" nationalPrefix="0"
-               mobileNumberPortableRegion="true">
+               nationalPrefixForParsing="(000[259]\d{6})$|(?:(?:003768)0?)|0"
+               nationalPrefixTransformRule="$1" mobileNumberPortableRegion="true">
       <availableFormats>
         <!-- National-only toll-free numbers (0037, 0066, 0077 and 0088). -->
         <numberFormat pattern="(\d{4})(\d{4})">
@@ -15913,8 +15947,7 @@
             8(?:
               3[89]|
               47|
-              51|
-              63
+              51
             )|
             9(?:
               80|
@@ -15952,8 +15985,7 @@
                 96
               )|
               477|
-              51[2-9]|
-              636
+              51[2-9]
             )|
             9(?:
               802|
@@ -15998,8 +16030,7 @@
                 96[2457-9]
               )|
               477|
-              51[2-9]|
-              636[457-9]
+              51[2-9]
             )|
             9(?:
               802|
@@ -16071,7 +16102,7 @@
             )|
             5(?:
               2|
-              3[045]|
+              3[0459]|
               4[0-369]|
               5[29]|
               8[02389]|
@@ -16087,7 +16118,7 @@
             )|
             8(?:
               2[124589]|
-              3[27-9]|
+              3[26-9]|
               49|
               51|
               6|
@@ -16152,12 +16183,17 @@
               [45]|
               6[248]|
               7[2-47]|
-              8[1-9]
+              8[1-9]|
+              9[29]
             )|
             5(?:
               2|
-              3[045]|
+              3(?:
+                [045]|
+                9[0-8]
+              )|
               4[0-369]|
+              5[29]|
               8[02389]|
               9[0-3]
             )|
@@ -16180,13 +16216,17 @@
                 4[0-39]|
                 9[0-2469]
               )|
+              3(?:
+                [29]|
+                60
+              )|
               49|
               51|
               6(?:
                 [0-24]|
                 36|
                 5[0-3589]|
-                72|
+                7[23]|
                 9[01459]
               )|
               7[0-468]|
@@ -16205,11 +16245,6 @@
                 4[0178]
               )
             )|
-            (?:
-              49|
-              55|
-              83
-            )[29]|
             (?:
               264|
               837
@@ -16286,7 +16321,14 @@
             )|
             5(?:
               2|
-              3[045]|
+              3(?:
+                [045]|
+                9(?:
+                  [0-58]|
+                  6[4-9]|
+                  7[0-35689]
+                )
+              )|
               4[0-369]|
               5[29]|
               8[02389]|
@@ -16313,6 +16355,7 @@
               )|
               3(?:
                 [29]|
+                60|
                 7(?:
                   [017-9]|
                   6[6-8]
@@ -16322,7 +16365,7 @@
               51|
               6(?:
                 [0-24]|
-                36[23]|
+                36[2-57-9]|
                 5(?:
                   [0-389]|
                   5[23]
@@ -16331,7 +16374,10 @@
                   [01]|
                   9[178]
                 )|
-                72|
+                7(?:
+                  2[2-468]|
+                  3[78]
+                )|
                 9[0145]
               )|
               7[0-468]|
@@ -16371,161 +16417,6 @@
             (?:
               48|
               8292|
-              9[23]
-            )[1-9]|
-            (?:
-              47[59]|
-              59[89]|
-              8(?:
-                68|
-                9
-              )
-            )[019]
-          </leadingDigits>
-          <leadingDigits>
-            1(?:
-              1|
-              5(?:
-                4[018]|
-                5[017]
-              )|
-              77|
-              88|
-              9[69]
-            )|
-            2(?:
-              2[127]|
-              3[0-269]|
-              4[59]|
-              5(?:
-                [1-3]|
-                5[0-69]|
-                7[015-9]|
-                9(?:
-                  17|
-                  99
-                )
-              )|
-              6(?:
-                2|
-                4[016-9]
-              )|
-              7(?:
-                [1-35]|
-                8[0189]
-              )|
-              8(?:
-                [16]|
-                3[0134]|
-                9[0-5]
-              )|
-              9(?:
-                [028]|
-                17|
-                3[015-9]
-              )
-            )|
-            4(?:
-              2(?:
-                [13-79]|
-                8[014-6]
-              )|
-              3[0-57]|
-              [45]|
-              6[248]|
-              7[2-47]|
-              9[29]
-            )|
-            5(?:
-              2|
-              3[045]|
-              4[0-369]|
-              5[29]|
-              8[02389]|
-              9[0-3]
-            )|
-            7(?:
-              2[02-46-9]|
-              34|
-              [58]|
-              6[0249]|
-              7[57]|
-              9(?:
-                [23]|
-                4[0-59]|
-                5[01569]|
-                6[0167]
-              )
-            )|
-            8(?:
-              2(?:
-                [1258]|
-                4[0-39]|
-                9(?:
-                  [019]|
-                  4[1-3]|
-                  6(?:
-                    [0-47-9]|
-                    5[01346-9]
-                  )
-                )
-              )|
-              3(?:
-                [29]|
-                7(?:
-                  [017-9]|
-                  6[6-8]
-                )
-              )|
-              49|
-              51|
-              6(?:
-                [0-24]|
-                36[23]|
-                5(?:
-                  [0-389]|
-                  5[23]
-                )|
-                6(?:
-                  [01]|
-                  9[178]
-                )|
-                72|
-                9[0145]
-              )|
-              7[0-468]|
-              8[68]
-            )|
-            9(?:
-              4[15]|
-              5[138]|
-              6[1-3]|
-              7[156]|
-              8[189]|
-              9(?:
-                [1289]|
-                3(?:
-                  31|
-                  4[357]
-                )|
-                4[0178]
-              )
-            )|
-            (?:
-              223|
-              8699
-            )[014-9]|
-            (?:
-              25[0468]|
-              422|
-              838
-            )[01]|
-            (?:
-              48|
-              829(?:
-                2|
-                66
-              )|
               9[23]
             )[1-9]|
             (?:
@@ -16857,10 +16748,7 @@
       <generalDesc>
         <nationalNumberPattern>
           8\d{9}|
-          (?:
-            [235-8]\d|
-            99
-          )\d{7}
+          [235-9]\d{8}
         </nationalNumberPattern>
       </generalDesc>
       <!-- Extra area codes found on Web Search: 3147. -->
@@ -16945,7 +16833,10 @@
               55
             )|
             88[08]|
-            99[05-9]
+            9(?:
+              12|
+              9[05-9]
+            )
           )\d{6}
         </nationalNumberPattern>
       </mobile>
@@ -17572,7 +17463,7 @@
             22[13]\d
           )\d{4,5}|
           1(?:
-            0[1-46-9]|
+            0[0-46-9]|
             [16-9]\d|
             2[013-9]
           )\d{6,7}
@@ -18651,14 +18542,9 @@
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
-        <possibleLengths national="8,9"/>
+        <possibleLengths national="8"/>
         <exampleNumber>21234567</exampleNumber>
-        <nationalNumberPattern>
-          (?:
-            2\d{3}|
-            33333
-          )\d{4}
-        </nationalNumberPattern>
+        <nationalNumberPattern>2\d{7}</nationalNumberPattern>
       </fixedLine>
       <!-- West Africa Telecom seems to be a mobile company from their website. -->
       <mobile>
@@ -19597,7 +19483,7 @@
             0[079]|
             [14]3|
             [27][79]|
-            30|
+            3[03-7]|
             5[0-268]|
             87
           )\d{4}
@@ -19638,7 +19524,7 @@
               395|
               76[018]
             )\d|
-            475[0-2]
+            475[0-5]
           )\d{4}
         </nationalNumberPattern>
       </voip>
@@ -20060,7 +19946,6 @@
               )\d|
               4(?:
                 2[29]|
-                39|
                 62|
                 7[0-2]|
                 83
@@ -20075,7 +19960,6 @@
               4(?:
                 0\d|
                 [26]2|
-                39|
                 7[0-2]|
                 83
               )|
@@ -20120,10 +20004,7 @@
                   3\d|
                   8[01459]
                 )\d|
-                4(?:
-                  39|
-                  [67]0
-                )
+                4[67]0
               )
             )
           )\d{4}|
@@ -20404,17 +20285,23 @@
         <exampleNumber>53123456</exampleNumber>
         <nationalNumberPattern>
           [12]2[1-3]\d{5,6}|
-          7(?:
-            0[0-5]\d|
-            128
-          )\d{4}|
           (?:
-            [12](?:
-              1|
-              27
-            )|
-            5[368]
-          )\d{6}|
+            (?:
+              [12](?:
+                1|
+                27
+              )|
+              5[368]
+            )\d\d|
+            7(?:
+              0(?:
+                [0-5]\d|
+                7[078]|
+                80
+              )|
+              128
+            )
+          )\d{4}|
           [12](?:
             3[2-8]|
             4[2-68]|
@@ -20428,7 +20315,7 @@
         <nationalNumberPattern>
           (?:
             83[01]|
-            920
+            92[039]
           )\d{5}|
           (?:
             5[05]|
@@ -20703,8 +20590,8 @@
             [03-7]\d|
             10|
             2[7-9]|
-            8[09]|
-            9[4-9]
+            8[0-39]|
+            9[04-9]
           )\d{4}
         </nationalNumberPattern>
       </fixedLine>
@@ -20735,8 +20622,8 @@
         <exampleNumber>976612345</exampleNumber>
         <nationalNumberPattern>
           9(?:
-            397[01]|
-            477[0-2]|
+            397[0-2]|
+            477[0-5]|
             76(?:
               6\d|
               7[0-367]
@@ -21042,7 +20929,7 @@
             )|
             4(?:
               [013568]\d|
-              2[4-7]
+              2[4-8]
             )|
             54(?:
               [3-5]\d|
@@ -21076,8 +20963,8 @@
               9[0-8]
             )|
             7(?:
-              0[01]|
-              3[03]
+              0[0-2]|
+              3[013]
             )
           )\d{5}
         </nationalNumberPattern>
@@ -21726,7 +21613,7 @@
               )|
               7(?:
                 [0-4]\d|
-                5[0-6]
+                5[0-7]
               )
             )|
             (?:
@@ -22064,7 +21951,7 @@
           <leadingDigits>
             [089]|
             2[013]|
-            7[04]
+            7[047]
           </leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
@@ -22105,7 +21992,7 @@
         <nationalNumberPattern>
           (?:
             23|
-            7[04]|
+            7[047]|
             [89]\d
           )\d{6}
         </nationalNumberPattern>
@@ -22569,14 +22456,11 @@
                internationalPrefix="00" mobileNumberPortableRegion="true">
       <availableFormats>
         <numberFormat pattern="(\d{3})(\d{2})(\d{3})">
-          <leadingDigits>
-            [489]|
-            59
-          </leadingDigits>
+          <leadingDigits>8</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <numberFormat pattern="(\d{2})(\d{2})(\d{2})(\d{2})">
-          <leadingDigits>[235-7]</leadingDigits>
+          <leadingDigits>[2-79]</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
@@ -22610,7 +22494,6 @@
         <nationalNumberPattern>
           (?:
             4[015-8]|
-            59|
             9\d
           )\d{6}
         </nationalNumberPattern>
@@ -22938,14 +22821,20 @@
         <possibleLengths national="[8-10]"/>
         <exampleNumber>211234567</exampleNumber>
         <nationalNumberPattern>
-          2[0-27-9]\d{7,8}|
-          21\d{6}
+          2(?:
+            [0-27-9]\d|
+            6
+          )\d{6,7}|
+          2(?:
+            1\d|
+            75
+          )\d{5}
         </nationalNumberPattern>
       </mobile>
       <pager>
         <possibleLengths national="8,9"/>
-        <exampleNumber>26123456</exampleNumber>
-        <nationalNumberPattern>[28]6\d{6,7}</nationalNumberPattern>
+        <exampleNumber>86123456</exampleNumber>
+        <nationalNumberPattern>86\d{6,7}</nationalNumberPattern>
       </pager>
       <!-- These are the toll free patterns used, by Telecom and Telstra/Clear, but they are
            referred to as 'Value-added service' in the phone plan for some reason. 85 numbers are
@@ -23030,7 +22919,7 @@
       <fixedLine>
         <possibleLengths national="8"/>
         <exampleNumber>23123456</exampleNumber>
-        <nationalNumberPattern>2[2-6]\d{6}</nationalNumberPattern>
+        <nationalNumberPattern>2[1-6]\d{6}</nationalNumberPattern>
       </fixedLine>
       <mobile>
         <possibleLengths national="8"/>
@@ -23040,6 +22929,7 @@
           (?:
             7(?:
               [1289]\d|
+              69|
               7[0-5]
             )|
             9(?:
@@ -23879,7 +23769,7 @@
         <nationalNumberPattern>
           3(?:
             [0-24]\d|
-            3[0-7]|
+            3[0-79]|
             55|
             64
           )\d{7}
@@ -24104,7 +23994,7 @@
               [145]\d|
               3[1-5]
             )|
-            2[0-4]\d
+            2\d\d
           )\d{4}|
           (?:
             45|
@@ -24184,8 +24074,8 @@
         <exampleNumber>430123</exampleNumber>
         <nationalNumberPattern>
           (?:
-            4[1-356]|
-            50
+            4[1-35-7]|
+            5[01]
           )\d{4}
         </nationalNumberPattern>
       </fixedLine>
@@ -24810,12 +24700,7 @@
       <pager>
         <possibleLengths national="7"/>
         <exampleNumber>2123456</exampleNumber>
-        <nationalNumberPattern>
-          2(?:
-            1\d|
-            61
-          )\d{4}
-        </nationalNumberPattern>
+        <nationalNumberPattern>2[16]\d{5}</nationalNumberPattern>
       </pager>
       <!-- Prefix 800 with 9 digit length is added based on user report. -->
       <tollFree>
@@ -24860,7 +24745,7 @@
             2\d\d|
             3(?:
               0\d|
-              1[0-3]
+              1[0-5]
             )
           )\d{4}
         </nationalNumberPattern>
@@ -24869,30 +24754,18 @@
         <possibleLengths national="9"/>
         <exampleNumber>692123456</exampleNumber>
         <nationalNumberPattern>
-          (?:
-            69(?:
-              2\d\d|
-              3(?:
-                0[0-46]|
-                1[013]|
-                2[0-2]|
-                3[0-39]|
-                4\d|
-                5[0-5]|
-                6[0-6]|
-                7[0-27]|
-                8[0-8]|
-                9[0-479]
-              )
-            )|
-            9(?:
-              399[0-3]|
-              479[0-2]|
-              76(?:
-                2[27]|
-                3[0-37]|
-                9\d
-              )
+          69(?:
+            2\d\d|
+            3(?:
+              [06][0-6]|
+              1[013]|
+              2[0-2]|
+              3[0-39]|
+              4\d|
+              5[0-5]|
+              7[0-27]|
+              8[0-8]|
+              9[0-479]
             )
           )\d{4}
         </nationalNumberPattern>
@@ -24920,6 +24793,20 @@
           )\d{6}
         </nationalNumberPattern>
       </sharedCost>
+      <voip>
+        <possibleLengths national="9"/>
+        <exampleNumber>939901234</exampleNumber>
+        <nationalNumberPattern>
+          9(?:
+            399[0-3]|
+            479[0-5]|
+            76(?:
+              2[27]|
+              3[0-37]
+            )
+          )\d{4}
+        </nationalNumberPattern>
+      </voip>
     </territory>
 
     <!-- Romania (RO) -->
@@ -25998,7 +25885,7 @@
           <leadingDigits>
             [369]|
             8(?:
-              0[1-6]|
+              0[1-8]|
               [1-9]
             )
           </leadingDigits>
@@ -26047,12 +25934,12 @@
         <exampleNumber>81234567</exampleNumber>
         <nationalNumberPattern>
           8(?:
-            06[0-689]|
+            08[01]|
             95[0-2]
           )\d{4}|
           (?:
             8(?:
-              0[1-5]|
+              0[1-7]|
               [1-8]\d|
               9[0-4]
             )|
@@ -26261,7 +26148,7 @@
           0\d{4}|
           (?:
             [489]\d|
-            [57]9
+            79
           )\d{6}
         </nationalNumberPattern>
       </generalDesc>
@@ -26277,7 +26164,6 @@
         <nationalNumberPattern>
           (?:
             4[015-8]|
-            59|
             9\d
           )\d{6}
         </nationalNumberPattern>
@@ -26720,8 +26606,9 @@
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3})(\d{3})">
           <leadingDigits>
-            [3478]|
+            [348]|
             64|
+            79|
             90
           </leadingDigits>
           <format>$1 $2 $3</format>
@@ -26730,10 +26617,8 @@
           <leadingDigits>
             1|
             28|
-            6(?:
-              0[5-7]|
-              [1-35-9]
-            )|
+            6[0-35-9]|
+            77|
             9[2-9]
           </leadingDigits>
           <format>$1 $2</format>
@@ -26783,13 +26668,10 @@
               (?:
                 3[59]|
                 4[89]|
-                79|
+                6\d|
+                7[79]|
                 8[08]
               )\d|
-              6(?:
-                0[5-7]|
-                [1-9]\d
-              )|
               9(?:
                 0\d|
                 [2-9]
@@ -26966,28 +26848,25 @@
         <exampleNumber>21234567</exampleNumber>
         <nationalNumberPattern>
           2(?:
-            [1-6]\d{3}|
-            [79]90[034]|
-            890[0245]
-          )\d{3}
+            79(?:
+              0[0347-9]|
+              [1-9]\d
+            )|
+            89(?:
+              0[024589]|
+              [1-9]\d
+            )
+          )\d{3}|
+          2(?:
+            [1-69]\d|
+            [78][0-8]
+          )\d{5}
         </nationalNumberPattern>
       </fixedLine>
       <mobile>
         <possibleLengths national="8"/>
         <exampleNumber>70123456</exampleNumber>
-        <nationalNumberPattern>
-          66(?:
-            [02-9]\d\d|
-            1(?:
-              [02-9]\d|
-              16
-            )
-          )\d{3}|
-          (?:
-            6[0-57-9]|
-            7\d
-          )\d{6}
-        </nationalNumberPattern>
+        <nationalNumberPattern>[67]\d{7}</nationalNumberPattern>
       </mobile>
       <!-- Toll free numbers are either 800 NNNN or 800 NNNN NNNN. -->
       <tollFree>
@@ -27551,8 +27430,8 @@
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{2})(\d{4})">
           <leadingDigits>
-            [34]7|
-            91[78]
+            44[04]|
+            [34]7
           </leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
@@ -27582,7 +27461,7 @@
               72
             )|
             4(?:
-              46|
+              4[046]|
               74|
               87
             )
@@ -27596,9 +27475,12 @@
         <possibleLengths national="9"/>
         <exampleNumber>917123456</exampleNumber>
         <nationalNumberPattern>
-          41[18]\d{6}|
           (?:
-            0[0-27]|
+            41[18]|
+            81[1-9]
+          )\d{6}|
+          (?:
+            0[0-57-9]|
             1[017]|
             2[02]|
             [34]0|
@@ -28851,7 +28733,8 @@
             [01578]\d|
             20|
             36|
-            [46][0-4]|
+            4[0-4]|
+            6[0-5]|
             9[89]
           )\d{6}
         </nationalNumberPattern>
@@ -28922,7 +28805,8 @@
           )\d{4}|
           (?:
             4722|
-            505[2-57-9]
+            505[2-57-9]|
+            983[29]
           )\d{6}|
           (?:
             2(?:
@@ -29022,7 +28906,8 @@
           )\d{4}|
           (?:
             4722|
-            505[2-57-9]
+            505[2-57-9]|
+            983[29]
           )\d{6}|
           (?:
             2(?:
@@ -29279,12 +29164,13 @@
                internationalPrefix="810" nationalPrefix="8">
       <availableFormats>
         <numberFormat pattern="(\d{2})(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP $FG">
-          <leadingDigits>[35-9]</leadingDigits>
+          <leadingDigits>[235-9]</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
       </availableFormats>
       <generalDesc>
         <nationalNumberPattern>
+          200\d{6}|
           (?:
             33|
             [5-79]\d|
@@ -29385,11 +29271,14 @@
         <nationalNumberPattern>
           (?:
             (?:
-              33|
-              50|
-              88|
-              9[0-57-9]
-            )\d{3}|
+              200[01]|
+              (?:
+                33|
+                50|
+                88|
+                9[0-57-9]
+              )\d\d
+            )\d|
             6(?:
               1(?:
                 2(?:
@@ -30289,12 +30178,12 @@
         <!-- Format for old mobile ranges and VOIP. -->
         <numberFormat pattern="(\d{2})(\d{3})(\d{2})(\d{2})" nationalPrefixFormattingRule="$NP$FG"
                       nationalPrefixOptionalWhenFormatting="true">
-          <leadingDigits>[69]</leadingDigits>
+          <leadingDigits>6</leadingDigits>
           <format>$1 $2 $3 $4</format>
         </numberFormat>
         <numberFormat pattern="(\d{3})(\d{3})(\d{3})" nationalPrefixFormattingRule="$NP$FG"
                       nationalPrefixOptionalWhenFormatting="true">
-          <leadingDigits>[3578]</leadingDigits>
+          <leadingDigits>[357-9]</leadingDigits>
           <format>$1 $2 $3</format>
         </numberFormat>
         <!-- 2-digit area codes (big cities) -->
@@ -30724,20 +30613,17 @@
     <!-- http://en.wikipedia.org/wiki/Telephone_numbers_in_France -->
     <!-- http://www.comores-online.com/mwezinet/internet/262 -->
     <!-- http://www.arcep.fr/index.php?id=2137&bloc=0596&CMD=RESULTS_NUMEROTATION -->
-    <territory id="YT" countryCode="262" leadingDigits="269|63|9398" internationalPrefix="00"
-               nationalPrefix="0">
+    <territory id="YT" countryCode="262" internationalPrefix="00" nationalPrefix="0">
       <generalDesc>
         <nationalNumberPattern>
           (?:
-            (?:
-              (?:
-                26|
-                63
-              )9|
-              80\d
-            )\d|
-            9398
-          )\d{5}
+            80|
+            9\d
+          )\d{7}|
+          (?:
+            26|
+            63
+          )9\d{6}
         </nationalNumberPattern>
       </generalDesc>
       <fixedLine>
@@ -30746,7 +30632,7 @@
         <nationalNumberPattern>
           269(?:
             0[0-467]|
-            5[0-3]|
+            5[0-4]|
             6\d|
             [78]0
           )\d{4}
@@ -30756,17 +30642,14 @@
         <possibleLengths national="9"/>
         <exampleNumber>639012345</exampleNumber>
         <nationalNumberPattern>
-          (?:
-            639(?:
-              0[0-79]|
-              1[019]|
-              [267]\d|
-              3[09]|
-              40|
-              5[05-9]|
-              9[04-79]
-            )|
-            9398[01]
+          639(?:
+            0[0-79]|
+            1[019]|
+            [267]\d|
+            3[09]|
+            40|
+            5[05-9]|
+            9[04-79]
           )\d{4}
         </nationalNumberPattern>
       </mobile>
@@ -30776,6 +30659,19 @@
         <exampleNumber>801234567</exampleNumber>
         <nationalNumberPattern>80\d{7}</nationalNumberPattern>
       </tollFree>
+      <voip>
+        <possibleLengths national="9"/>
+        <exampleNumber>939801234</exampleNumber>
+        <nationalNumberPattern>
+          9(?:
+            (?:
+              39|
+              47
+            )8[01]|
+            769\d
+          )\d{4}
+        </nationalNumberPattern>
+      </voip>
     </territory>
 
     <!-- South Africa (ZA) -->


### PR DESCRIPTION
Hi! 👋🏻 

I'm encountering a bug with Australian phone numbers that are valid in newer `libphonenumber` versions but not valid in current version. This PR updates the metadata to the current version using the available Mix task. I tested the specific phone number with `iex -S mix` with the current version and the updated version, and it works as expected.

Thanks