### PR TITLE
Remove :warn log level in favor of :warning

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,4 +1,4 @@
 import Config
 
 config :ex_phone_number,
-  log_level: :warn
+  log_level: :warning


### PR DESCRIPTION
Hi there 🙌 
The PR is to get rid of these warnings below which appear after upgrade on elixir 1.15.

```
==> ex_phone_number
Compiling 22 files (.ex)
warning: the log level :warn is deprecated, use :warning instead
  (logger 1.15.2) lib/logger.ex:1137: Logger.elixir_level_to_erlang_level/1
  (logger 1.15.2) lib/logger.ex:618: anonymous fn/2 in Logger.configure/1
  (elixir 1.15.2) lib/enum.ex:2510: Enum."-reduce/3-lists^foldl/2-0-"/3
  (logger 1.15.2) lib/logger.ex:616: Logger.configure/1
  lib/ex_phone_number/metadata/phone_metadata.ex:76: (module)
  (elixir 1.15.2) src/elixir_compiler.erl:66: :elixir_compiler.dispatch/4
```
