### PR TITLE
Standardize phone number error messages for consistency

### DIFF
--- a/lib/ex_phone_number/constants/error_messages.ex
+++ b/lib/ex_phone_number/constants/error_messages.ex
@@ -3,9 +3,9 @@ defmodule ExPhoneNumber.Constants.ErrorMessages do
 
   def invalid_country_code(), do: "Invalid country calling code"
 
-  def not_a_number(), do: "The string supplied did not seem to be a phone number"
+  def not_a_number(), do: "The string supplied is not a valid phone number"
 
-  def too_short_after_idd(), do: "Phone number too short after IDD"
+  def too_short_after_idd(), do: "The phone number is too short after IDD"
 
   def too_short_nsn(), do: "The string supplied is too short to be a phone number"
 


### PR DESCRIPTION
- Reworded 'not_a_number' error for clarity and consistency
- Adjusted 'too_short_after_idd' message to match overall style