### PR TITLE
Make debug logging configurable

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,5 @@
 import Config
 
 config :ex_phone_number,
-  log_level: :debug
+  log_level: :debug,
+  debug_log: System.get_env("DEBUG") in ["true", "1", "yes"]

--- a/lib/ex_phone_number/metadata/phone_metadata.ex
+++ b/lib/ex_phone_number/metadata/phone_metadata.ex
@@ -70,7 +70,6 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
   alias ExPhoneNumber.Metadata.PhoneNumberDescription
 
   require Logger
-  Logger.configure(level: Application.compile_env(:ex_phone_number, :log_level, :warning))
 
   def from_xpath_node(xpath_node) do
     kwlist =

--- a/lib/ex_phone_number/metadata/phone_metadata.ex
+++ b/lib/ex_phone_number/metadata/phone_metadata.ex
@@ -242,18 +242,18 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
   end
 
   def put_default_values(phone_metadata = %PhoneMetadata{}) do
-    Logger.debug("----- Territory -----")
-    Logger.debug(fn -> "#{inspect(phone_metadata)}" end)
-    Logger.debug(fn -> "region_code: #{inspect(phone_metadata.id)}" end)
+    log_debug("----- Territory -----")
+    log_debug(fn -> "#{inspect(phone_metadata)}" end)
+    log_debug(fn -> "region_code: #{inspect(phone_metadata.id)}" end)
 
     phone_metadata =
       if has_national_prefix?(phone_metadata) do
-        Logger.debug("has national_prefix")
+        log_debug("has national_prefix")
 
         if not has_national_prefix_for_parsing?(phone_metadata) do
-          Logger.debug("has not national_prefix_for_parsing")
+          log_debug("has not national_prefix_for_parsing")
 
-          Logger.debug(fn ->
+          log_debug(fn ->
             "national_prefix_for_parsing: #{inspect(phone_metadata.national_prefix)}"
           end)
 
@@ -262,7 +262,7 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
           phone_metadata
         end
       else
-        Logger.debug("has not national_prefix")
+        log_debug("has not national_prefix")
         phone_metadata
       end
 
@@ -271,7 +271,7 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
       | national_prefix_formatting_rule: get_national_prefix_formatting_rule(phone_metadata)
     }
 
-    Logger.debug(fn ->
+    log_debug(fn ->
       "national_prefix_formatting_rule: #{inspect(phone_metadata.national_prefix_formatting_rule)}"
     end)
 
@@ -280,11 +280,11 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
       | carrier_code_formatting_rule: get_domestic_carrier_code_formatting_rule(phone_metadata)
     }
 
-    Logger.debug(fn ->
+    log_debug(fn ->
       "carrier_code_formatting_rule: #{inspect(phone_metadata.carrier_code_formatting_rule)}"
     end)
 
-    Logger.debug(fn ->
+    log_debug(fn ->
       "available_formats count: #{inspect(length(phone_metadata.available_formats))}"
     end)
 
@@ -296,7 +296,7 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
         if is_nil(ele), do: acc, else: acc ++ [ele]
       end)
 
-    Logger.debug(fn -> "number_format count: #{inspect(length(number_format))}" end)
+    log_debug(fn -> "number_format count: #{inspect(length(number_format))}" end)
 
     intl_number_format =
       List.foldl(formats, [], fn x, acc ->
@@ -304,7 +304,7 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
         if is_nil(ele), do: acc, else: acc ++ [ele]
       end)
 
-    Logger.debug(fn -> "intl_number_format count: #{inspect(length(intl_number_format))}" end)
+    log_debug(fn -> "intl_number_format count: #{inspect(length(intl_number_format))}" end)
 
     phone_metadata = %{
       phone_metadata
@@ -428,8 +428,8 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
   end
 
   def get_number_format(%{number_format: number_format}, %PhoneMetadata{} = phone_metadata) do
-    Logger.debug("---> number_format")
-    Logger.debug(fn -> "\t#{inspect(number_format)}" end)
+    log_debug("---> number_format")
+    log_debug(fn -> "\t#{inspect(number_format)}" end)
 
     number_format =
       Map.merge(
@@ -443,7 +443,7 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
         end
       )
 
-    Logger.debug(fn -> "\tnational_prefix_formatting_rule: #{inspect(number_format.national_prefix_formatting_rule)}" end)
+    log_debug(fn -> "\tnational_prefix_formatting_rule: #{inspect(number_format.national_prefix_formatting_rule)}" end)
 
     number_format =
       Map.merge(
@@ -457,7 +457,7 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
         end
       )
 
-    Logger.debug(fn ->
+    log_debug(fn ->
       ~s"\tnational_prefix_optional_when_formatting: #{inspect(number_format.national_prefix_optional_when_formatting)}"
     end)
 
@@ -477,7 +477,7 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
         end
       )
 
-    Logger.debug(fn ->
+    log_debug(fn ->
       ~s"\tdomestic_carrier_code_formatting_rule: #{inspect(number_format.domestic_carrier_code_formatting_rule)}"
     end)
 
@@ -494,13 +494,13 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
         }
       )
 
-    Logger.debug(fn ->
+    log_debug(fn ->
       ~s"\tleading_digits_pattern: #{inspect(number_format.leading_digits_pattern)}"
     end)
 
     intl_number_format = get_intl_format(number_format)
-    Logger.debug("---> intl_number_format")
-    Logger.debug(fn -> "\t#{inspect(intl_number_format)}" end)
+    log_debug("---> intl_number_format")
+    log_debug(fn -> "\t#{inspect(intl_number_format)}" end)
     %{number_format: number_format, intl_number_format: intl_number_format}
   end
 
@@ -589,6 +589,14 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
       }
     else
       process_phone_number_description(description, general)
+    end
+  end
+
+  defp log_debug(message_or_func, metadata \\ []) do
+    if Application.get_env(:ex_phone_number, :debug_log) do
+      Logger.debug(message_or_func, metadata)
+    else
+      :ok
     end
   end
 end

--- a/lib/ex_phone_number/metadata/phone_metadata.ex
+++ b/lib/ex_phone_number/metadata/phone_metadata.ex
@@ -244,8 +244,8 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
 
   def put_default_values(phone_metadata = %PhoneMetadata{}) do
     Logger.debug("----- Territory -----")
-    Logger.debug("#{inspect(phone_metadata)}")
-    Logger.debug("region_code: #{inspect(phone_metadata.id)}")
+    Logger.debug(fn -> "#{inspect(phone_metadata)}" end)
+    Logger.debug(fn -> "region_code: #{inspect(phone_metadata.id)}" end)
 
     phone_metadata =
       if has_national_prefix?(phone_metadata) do
@@ -253,7 +253,11 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
 
         if not has_national_prefix_for_parsing?(phone_metadata) do
           Logger.debug("has not national_prefix_for_parsing")
-          Logger.debug("national_prefix_for_parsing: #{inspect(phone_metadata.national_prefix)}")
+
+          Logger.debug(fn ->
+            "national_prefix_for_parsing: #{inspect(phone_metadata.national_prefix)}"
+          end)
+
           %{phone_metadata | national_prefix_for_parsing: phone_metadata.national_prefix}
         else
           phone_metadata
@@ -268,16 +272,23 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
       | national_prefix_formatting_rule: get_national_prefix_formatting_rule(phone_metadata)
     }
 
-    Logger.debug("national_prefix_formatting_rule: #{inspect(phone_metadata.national_prefix_formatting_rule)}")
+    Logger.debug(fn ->
+      "national_prefix_formatting_rule: #{inspect(phone_metadata.national_prefix_formatting_rule)}"
+    end)
 
     phone_metadata = %{
       phone_metadata
       | carrier_code_formatting_rule: get_domestic_carrier_code_formatting_rule(phone_metadata)
     }
 
-    Logger.debug("carrier_code_formatting_rule: #{inspect(phone_metadata.carrier_code_formatting_rule)}")
+    Logger.debug(fn ->
+      "carrier_code_formatting_rule: #{inspect(phone_metadata.carrier_code_formatting_rule)}"
+    end)
 
-    Logger.debug("available_formats count: #{inspect(length(phone_metadata.available_formats))}")
+    Logger.debug(fn ->
+      "available_formats count: #{inspect(length(phone_metadata.available_formats))}"
+    end)
+
     formats = get_number_format(phone_metadata)
 
     number_format =
@@ -286,7 +297,7 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
         if is_nil(ele), do: acc, else: acc ++ [ele]
       end)
 
-    Logger.debug("number_format count: #{inspect(length(number_format))}")
+    Logger.debug(fn -> "number_format count: #{inspect(length(number_format))}" end)
 
     intl_number_format =
       List.foldl(formats, [], fn x, acc ->
@@ -294,7 +305,7 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
         if is_nil(ele), do: acc, else: acc ++ [ele]
       end)
 
-    Logger.debug("intl_number_format count: #{inspect(length(intl_number_format))}")
+    Logger.debug(fn -> "intl_number_format count: #{inspect(length(intl_number_format))}" end)
 
     phone_metadata = %{
       phone_metadata
@@ -419,7 +430,7 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
 
   def get_number_format(%{number_format: number_format}, %PhoneMetadata{} = phone_metadata) do
     Logger.debug("---> number_format")
-    Logger.debug("\t#{inspect(number_format)}")
+    Logger.debug(fn -> "\t#{inspect(number_format)}" end)
 
     number_format =
       Map.merge(
@@ -433,7 +444,7 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
         end
       )
 
-    Logger.debug("\tnational_prefix_formatting_rule: #{inspect(number_format.national_prefix_formatting_rule)}")
+    Logger.debug(fn -> "\tnational_prefix_formatting_rule: #{inspect(number_format.national_prefix_formatting_rule)}" end)
 
     number_format =
       Map.merge(
@@ -447,7 +458,9 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
         end
       )
 
-    Logger.debug(~s"\tnational_prefix_optional_when_formatting: #{inspect(number_format.national_prefix_optional_when_formatting)}")
+    Logger.debug(fn ->
+      ~s"\tnational_prefix_optional_when_formatting: #{inspect(number_format.national_prefix_optional_when_formatting)}"
+    end)
 
     number_format =
       Map.merge(
@@ -465,7 +478,9 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
         end
       )
 
-    Logger.debug(~s"\tdomestic_carrier_code_formatting_rule: #{inspect(number_format.domestic_carrier_code_formatting_rule)}")
+    Logger.debug(fn ->
+      ~s"\tdomestic_carrier_code_formatting_rule: #{inspect(number_format.domestic_carrier_code_formatting_rule)}"
+    end)
 
     number_format =
       Map.merge(
@@ -480,11 +495,13 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
         }
       )
 
-    Logger.debug(~s"\tleading_digits_pattern: #{inspect(number_format.leading_digits_pattern)}")
+    Logger.debug(fn ->
+      ~s"\tleading_digits_pattern: #{inspect(number_format.leading_digits_pattern)}"
+    end)
 
     intl_number_format = get_intl_format(number_format)
     Logger.debug("---> intl_number_format")
-    Logger.debug("\t#{inspect(intl_number_format)}")
+    Logger.debug(fn -> "\t#{inspect(intl_number_format)}" end)
     %{number_format: number_format, intl_number_format: intl_number_format}
   end
 


### PR DESCRIPTION
I noticed that `Logger.configure` is called during compilation to try and shut the logger up for normal use. Instead I lifted all of the `Logger.debug` calls to a helper `log_debug` function that effectively no-ops when not in debug mode.

In `exqlite` I use the `V=1` environment variable to spit out compilation debug info for make files. I don't know if this is something desired for the project, so I just stuck with `DEBUG` as the env var.

With debug log enabled

```
# DEBUG=yes mix compile --force
Compiling 22 files (.ex)

10:50:17.327 [debug] ----- Territory -----

10:50:17.334 [debug] %ExPhoneNumber.Metadata.P
.....
```

With debug log disabled

```
#mix compile --force
Compiling 22 files (.ex)
Generated ex_phone_number app
```

You may also specify `debug_log: true` in your configuration prior to compilation as well.

```
config :ex_phone_number,
  log_level: :debug,
  debug_log: true
```

And of course, at runtime you can force it to `true` and execute the `PhoneMetadata` parsing and it'll log the data out.