### PR TITLE
use_strings_in_sweetxml

### DIFF
--- a/lib/ex_phone_number/metadata/normalize.ex
+++ b/lib/ex_phone_number/metadata/normalize.ex
@@ -1,0 +1,50 @@
+defmodule ExPhoneNumber.Metadata.Normalize do
+  def pattern(nil), do: nil
+  def pattern([]), do: nil
+  def pattern(""), do: nil
+
+  def pattern(pattern) when is_binary(pattern) do
+    pattern
+    |> String.replace(["\n", " "], "")
+    |> Regex.compile!()
+  end
+
+  def string(""), do: nil
+  def string(string) when is_binary(string), do: string
+
+  def boolean("true"), do: true
+  def boolean(_), do: false
+
+  def rule(nil), do: nil
+
+  def rule(char_list) when is_list(char_list),
+    do: char_list |> List.to_string() |> rule()
+
+  def rule(string) when is_binary(string) do
+    string
+    |> String.replace(~r/\$(\d)/, "\\\\g{\\g{1}}")
+  end
+
+  def range(""), do: nil
+
+  def range(string) when is_binary(string) do
+    string
+    |> String.replace(["\n", " "], "")
+    |> String.split(",")
+    |> Enum.flat_map(&range_to_list/1)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp range_to_list("[" <> range) do
+    range
+    |> String.trim_trailing("]")
+    |> String.split("-", parts: 2)
+    |> then(fn [from, to] -> Range.new(String.to_integer(from), String.to_integer(to)) end)
+    |> Enum.to_list()
+  end
+
+  defp range_to_list(number) do
+    [String.to_integer(number)]
+  end
+end

--- a/lib/ex_phone_number/metadata/number_format.ex
+++ b/lib/ex_phone_number/metadata/number_format.ex
@@ -1,4 +1,5 @@
 defmodule ExPhoneNumber.Metadata.NumberFormat do
+  alias ExPhoneNumber.Metadata.Normalize
   @moduledoc false
 
   # string
@@ -25,52 +26,18 @@ defmodule ExPhoneNumber.Metadata.NumberFormat do
     kwlist =
       xpath_node
       |> xmap(
-        pattern: ~x"./@pattern"s |> transform_by(&normalize_pattern/1),
-        format: ~x"./format/text()"s |> transform_by(&normalize_rule/1),
+        pattern: ~x"./@pattern"s |> transform_by(&Normalize.pattern/1),
+        format: ~x"./format/text()"s |> transform_by(&Normalize.rule/1),
         leading_digits_pattern: [
           ~x"./leadingDigits"el,
-          pattern: ~x"./text()"s |> transform_by(&normalize_pattern/1)
+          pattern: ~x"./text()"s |> transform_by(&Normalize.pattern/1)
         ],
-        national_prefix_formatting_rule: ~x"./@nationalPrefixFormattingRule"o |> transform_by(&normalize_string/1),
-        national_prefix_optional_when_formatting: ~x"./@nationalPrefixOptionalWhenFormatting"o |> transform_by(&normalize_boolean/1),
-        domestic_carrier_code_formatting_rule: ~x"./@carrierCodeFormattingRule"o |> transform_by(&normalize_string/1),
-        intl_format: ~x"./intlFormat/text()"o |> transform_by(&normalize_rule/1)
+        national_prefix_formatting_rule: ~x"./@nationalPrefixFormattingRule"so |> transform_by(&Normalize.string/1),
+        national_prefix_optional_when_formatting: ~x"./@nationalPrefixOptionalWhenFormatting"so |> transform_by(&Normalize.boolean/1),
+        domestic_carrier_code_formatting_rule: ~x"./@carrierCodeFormattingRule"so |> transform_by(&Normalize.string/1),
+        intl_format: ~x"./intlFormat/text()"o |> transform_by(&Normalize.rule/1)
       )
 
     struct(%NumberFormat{}, kwlist)
-  end
-
-  defp normalize_boolean(nil), do: nil
-
-  defp normalize_boolean(true_char_list)
-       when is_list(true_char_list) and length(true_char_list) == 4,
-       do: true
-
-  defp normalize_pattern(nil), do: nil
-  defp normalize_pattern(""), do: nil
-  defp normalize_pattern([]), do: nil
-
-  defp normalize_pattern(string) when is_binary(string) do
-    string
-    |> String.split(["\n", " "], trim: true)
-    |> List.to_string()
-    |> Regex.compile!()
-  end
-
-  defp normalize_string(nil), do: nil
-
-  defp normalize_string(char_list) when is_list(char_list) do
-    char_list
-    |> List.to_string()
-  end
-
-  defp normalize_rule(nil), do: nil
-
-  defp normalize_rule(char_list) when is_list(char_list),
-    do: char_list |> List.to_string() |> normalize_rule()
-
-  defp normalize_rule(string) when is_binary(string) do
-    string
-    |> String.replace(~r/\$(\d)/, "\\\\g{\\g{1}}")
   end
 end

--- a/lib/ex_phone_number/metadata/phone_number_description.ex
+++ b/lib/ex_phone_number/metadata/phone_number_description.ex
@@ -1,5 +1,9 @@
 defmodule ExPhoneNumber.Metadata.PhoneNumberDescription do
   @moduledoc false
+  import SweetXml
+
+  alias ExPhoneNumber.Metadata.Normalize
+  alias ExPhoneNumber.Metadata.PhoneNumberDescription
   # string
   defstruct national_number_pattern: nil,
             # list
@@ -7,19 +11,16 @@ defmodule ExPhoneNumber.Metadata.PhoneNumberDescription do
             # string
             example_number: nil
 
-  import SweetXml
-  alias ExPhoneNumber.Metadata.PhoneNumberDescription
-
   def from_xpath_node(nil), do: nil
 
   def from_xpath_node(xpath_node) do
     kwlist =
       xmap(
         xpath_node,
-        national_number_pattern: ~x"./nationalNumberPattern/text()"o |> transform_by(&normalize_pattern/1),
-        national_possible_lengths: ~x"./possibleLengths/@national"o |> transform_by(&normalize_range/1),
-        local_possible_lengths: ~x"./possibleLengths/@localOnly"o |> transform_by(&normalize_range/1),
-        example_number: ~x"./exampleNumber/text()"o |> transform_by(&normalize_string/1)
+        national_number_pattern: transform_by(~x"./nationalNumberPattern/text()"so, &Normalize.pattern/1),
+        national_possible_lengths: transform_by(~x"./possibleLengths/@national"so, &Normalize.range/1),
+        local_possible_lengths: transform_by(~x"./possibleLengths/@localOnly"so, &Normalize.range/1),
+        example_number: transform_by(~x"./exampleNumber/text()"so, &Normalize.string/1)
       )
 
     possible_lengths =
@@ -33,54 +34,5 @@ defmodule ExPhoneNumber.Metadata.PhoneNumberDescription do
       possible_lengths: possible_lengths,
       example_number: kwlist.example_number
     })
-  end
-
-  defp clean_string(string) when is_binary(string) do
-    string
-    |> String.split(["\n", " "], trim: true)
-    |> List.to_string()
-  end
-
-  defp normalize_string(nil), do: nil
-
-  defp normalize_string(char_list) when is_list(char_list),
-    do: char_list |> List.to_string() |> clean_string()
-
-  defp normalize_pattern(nil), do: nil
-
-  defp normalize_pattern(char_list) when is_list(char_list) do
-    char_list
-    |> List.to_string()
-    |> clean_string
-    |> Regex.compile!()
-  end
-
-  defp normalize_range(nil), do: nil
-
-  defp normalize_range(char_list) when is_list(char_list) do
-    char_list
-    |> List.to_string()
-    |> clean_string
-    |> String.split(",")
-    |> Enum.map(&range_to_list/1)
-    |> List.flatten()
-    |> Enum.sort()
-    |> Enum.uniq()
-  end
-
-  defp range_to_list(range_or_number) do
-    case String.first(range_or_number) do
-      "[" ->
-        [range_start, range_end] =
-          range_or_number
-          |> String.slice(1, String.length(range_or_number) - 2)
-          |> String.split("-")
-          |> Enum.map(fn n -> String.to_integer(n) end)
-
-        Enum.to_list(Range.new(range_start, range_end))
-
-      _ ->
-        String.to_integer(range_or_number)
-    end
   end
 end

--- a/lib/ex_phone_number/normalization.ex
+++ b/lib/ex_phone_number/normalization.ex
@@ -37,15 +37,16 @@ defmodule ExPhoneNumber.Normalization do
       new_char = Map.get(normalization_replacements, String.upcase(char))
 
       if new_char do
-        list ++ [new_char]
+        [new_char | list]
       else
         if remove_non_matches do
           list
         else
-          list ++ [char]
+          [char | list]
         end
       end
     end)
+    |> Enum.reverse()
     |> List.to_string()
   end
 


### PR DESCRIPTION
`~x` sigil can return a string - this way we can avoid using List.to_string in all the helpers.
I extracted the common functions to a module and optimized it a bit for example first run uniq then sort or used pattern matching.
I also formatted the files with styler - this changed the if orders for example with `if not` and `if !=`