### PR TITLE
No longer store regexes in module attributes for compatibility with OTP 28

### DIFF
--- a/lib/ex_phone_number/constants/patterns.ex
+++ b/lib/ex_phone_number/constants/patterns.ex
@@ -3,10 +3,8 @@ defmodule ExPhoneNumber.Constants.Patterns do
 
   alias ExPhoneNumber.Constants.Values
 
-  @unique_international_prefix "[\d]+(?:[~\u2053\u223C\uFF5E][\d]+)?"
-  @unique_international_prefix_regex Regex.compile(@unique_international_prefix)
   def unique_international_prefix() do
-    @unique_international_prefix_regex
+    Regex.compile("[\d]+(?:[~\u2053\u223C\uFF5E][\d]+)?")
   end
 
   def valid_punctuation() do

--- a/lib/ex_phone_number/formatting.ex
+++ b/lib/ex_phone_number/formatting.ex
@@ -15,7 +15,7 @@ defmodule ExPhoneNumber.Formatting do
 
       match_index =
         if not (leading_digits_pattern_size == 0) do
-          last_leading_digits_pattern = List.last(number_format.leading_digits_pattern)
+          last_leading_digits_pattern = List.last(number_format.leading_digits_pattern) |> Regex.compile!()
 
           case Regex.run(last_leading_digits_pattern, national_number, return: :index) do
             nil -> -1
@@ -105,7 +105,9 @@ defmodule ExPhoneNumber.Formatting do
             carrier_code_rule
           )
 
-        Regex.replace(formatting_pattern.pattern, number, number_rule)
+        formatting_pattern.pattern
+        |> Regex.compile!()
+        |> Regex.replace(number, number_rule)
       else
         if PhoneNumberFormats.national() == phone_number_format and
              not is_nil_or_empty?(formatting_pattern.national_prefix_formatting_rule) do
@@ -117,9 +119,13 @@ defmodule ExPhoneNumber.Formatting do
               global: false
             )
 
-          Regex.replace(formatting_pattern.pattern, number, number_rule)
+          formatting_pattern.pattern
+          |> Regex.compile!()
+          |> Regex.replace(number, number_rule)
         else
-          Regex.replace(formatting_pattern.pattern, number, formatting_pattern.format)
+          formatting_pattern.pattern
+          |> Regex.compile!()
+          |> Regex.replace(number, formatting_pattern.format)
         end
       end
 

--- a/lib/ex_phone_number/metadata/number_format.ex
+++ b/lib/ex_phone_number/metadata/number_format.ex
@@ -54,7 +54,6 @@ defmodule ExPhoneNumber.Metadata.NumberFormat do
     string
     |> String.split(["\n", " "], trim: true)
     |> List.to_string()
-    |> Regex.compile!()
   end
 
   defp normalize_string(nil), do: nil

--- a/lib/ex_phone_number/metadata/phone_metadata.ex
+++ b/lib/ex_phone_number/metadata/phone_metadata.ex
@@ -165,7 +165,6 @@ defmodule ExPhoneNumber.Metadata.PhoneMetadata do
     |> List.to_string()
     |> String.split(["\n", " "], trim: true)
     |> List.to_string()
-    |> Regex.compile!()
   end
 
   defp normalize_string(nil), do: nil

--- a/lib/ex_phone_number/metadata/phone_number_description.ex
+++ b/lib/ex_phone_number/metadata/phone_number_description.ex
@@ -52,7 +52,6 @@ defmodule ExPhoneNumber.Metadata.PhoneNumberDescription do
     char_list
     |> List.to_string()
     |> clean_string
-    |> Regex.compile!()
   end
 
   defp normalize_range(nil), do: nil

--- a/lib/ex_phone_number/normalization.ex
+++ b/lib/ex_phone_number/normalization.ex
@@ -9,6 +9,11 @@ defmodule ExPhoneNumber.Normalization do
     normalize_helper(number, Mappings.all_normalization_mappings(), false)
   end
 
+  def match_at_start?(string, pattern) when is_binary(string) and is_binary(pattern) do
+    pattern = Regex.compile!(pattern)
+    match_at_start?(string, pattern)
+  end
+
   def match_at_start?(string, pattern) when is_binary(string) and is_map(pattern) do
     case Regex.run(pattern, string, return: :index) do
       [{index, _length} | _tail] -> index == 0

--- a/lib/ex_phone_number/utilities.ex
+++ b/lib/ex_phone_number/utilities.ex
@@ -20,8 +20,10 @@ defmodule ExPhoneNumber.Utilities do
 
   def matches_entirely?(nil, _string), do: false
 
+  def matches_entirely?(regex, string) when is_map(regex), do: matches_entirely?(regex.source, string)
+
   def matches_entirely?(regex, string) do
-    regex = ~r/^(?:#{regex.source})$/
+    regex = ~r/^(?:#{regex})$/
 
     case Regex.run(regex, string, return: :index) do
       [{_index, length} | _tail] -> Kernel.byte_size(string) == length

--- a/test/ex_phone_number/metadata_test.exs
+++ b/test/ex_phone_number/metadata_test.exs
@@ -35,7 +35,7 @@ defmodule ExPhoneNumber.MetadataTest do
       end
 
       it "returns valid number_format(1).pattern", state do
-        assert ~r/(\d{3})(\d{3})(\d{4})/ == Enum.at(state[:us_metadata].number_format, 1).pattern
+        assert "(\\d{3})(\\d{3})(\\d{4})" == Enum.at(state[:us_metadata].number_format, 1).pattern
       end
 
       it "returns valid number_format(1).format", state do
@@ -43,7 +43,7 @@ defmodule ExPhoneNumber.MetadataTest do
       end
 
       it "returns valid general.national_number_pattern", state do
-        assert ~r/[13-689]\d{9}|2[0-35-9]\d{8}/ ==
+        assert "[13-689]\\d{9}|2[0-35-9]\\d{8}" ==
                  state[:us_metadata].general.national_number_pattern
       end
 
@@ -56,7 +56,7 @@ defmodule ExPhoneNumber.MetadataTest do
       end
 
       it "returns valid premium_rate.national_number_pattern", state do
-        assert ~r/900\d{7}/ == state[:us_metadata].premium_rate.national_number_pattern
+        assert "900\\d{7}" == state[:us_metadata].premium_rate.national_number_pattern
       end
 
       it "returns valid shared_cost.national_number_pattern", state do
@@ -100,12 +100,12 @@ defmodule ExPhoneNumber.MetadataTest do
       end
 
       it "returns valid number_format(5).leading_digits_pattern(0)", state do
-        assert ~r/900/ ==
+        assert "900" ==
                  Enum.at(Enum.at(state[:de_metadata].number_format, 5).leading_digits_pattern, 0)
       end
 
       it "returns valid number_format(5).pattern", state do
-        assert ~r/(\d{3})(\d{3,4})(\d{4})/ ==
+        assert "(\\d{3})(\\d{3,4})(\\d{4})" ==
                  Enum.at(state[:de_metadata].number_format, 5).pattern
       end
 
@@ -114,7 +114,7 @@ defmodule ExPhoneNumber.MetadataTest do
       end
 
       it "returns valid fixed_line.national_number_pattern", state do
-        assert ~r/(?:[24-6]\d{2}|3[03-9]\d|[789](?:0[2-9]|[1-9]\d))\d{1,8}/ ==
+        assert "(?:[24-6]\\d{2}|3[03-9]\\d|[789](?:0[2-9]|[1-9]\\d))\\d{1,8}" ==
                  state[:de_metadata].fixed_line.national_number_pattern
       end
 
@@ -131,7 +131,7 @@ defmodule ExPhoneNumber.MetadataTest do
       end
 
       it "returns valid premium_rate.national_number_pattern", state do
-        assert ~r/900([135]\d{6}|9\d{7})/ ==
+        assert "900([135]\\d{6}|9\\d{7})" ==
                  state[:de_metadata].premium_rate.national_number_pattern
       end
     end
@@ -170,12 +170,12 @@ defmodule ExPhoneNumber.MetadataTest do
       end
 
       it "returns valid number_format(3).pattern", state do
-        assert ~r/(\d)(\d{4})(\d{2})(\d{4})/ ==
+        assert "(\\d)(\\d{4})(\\d{2})(\\d{4})" ==
                  Enum.at(state[:ar_metadata].number_format, 3).pattern
       end
 
       it "returns valid intl_number_format(3).pattern", state do
-        assert ~r/(\d)(\d{4})(\d{2})(\d{4})/ ==
+        assert "(\\d)(\\d{4})(\\d{2})(\\d{4})" ==
                  Enum.at(state[:ar_metadata].intl_number_format, 3).pattern
       end
 
@@ -205,7 +205,7 @@ defmodule ExPhoneNumber.MetadataTest do
       end
 
       it "returns valid number_format(0).pattern", state do
-        assert ~r/(\d{4})(\d{4})/ == Enum.at(state[:un001_metadata].number_format, 0).pattern
+        assert "(\\d{4})(\\d{4})" == Enum.at(state[:un001_metadata].number_format, 0).pattern
       end
 
       it "returns valid toll_free.example_number", state do


### PR DESCRIPTION
In OTP 28 you cannot store regexes in module attributes anymore. This meant the metadata now has to store the pattern, and regexes need to be compiled in later steps.

It's quite a change IMO, so please let me know any feedback.