### PR TITLE
update ubuntu to 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - run: mix format --check-formatted
   test:
     name: Test on Elixir ${{ matrix.elixir }} (OTP ${{ matrix.otp }})
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         otp: ["23.3.4.18", "24.3.4.10"]


### PR DESCRIPTION
Cause github workflow not working deprecated ubuntu 20.04 (https://github.com/actions/runner-images/issues/11101)